### PR TITLE
Attempted addition to fix error with publishing to google

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -73,6 +73,9 @@ android {
    buildTypes {
        release {
            signingConfig signingConfigs.release
+           ndk {
+           	abiFilters 'armeabi-v7a','arm64-v8a','x86_64'
+           }
        }
    }
 }


### PR DESCRIPTION
Updated gradle file according to this post:

https://stackoverflow.com/questions/52795414/flutter-app-drops-java-lang-unsatisfiedlinkerror-couldnt-find-libflutter-so

to maybe resolve this error:

java.lang.RuntimeException: Unable to start activity ComponentInfo{com.umgc.summer2022/com.umgc.summer2022.MainActivity}: java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.UnsatisfiedLinkError: dalvik.system.PathClassLoader[DexPathList[[zip file "/system/framework/android.test.runner.jar", zip file "/system/framework/org.apache.http.legacy.boot.jar", zip file "/system/framework/android.test.mock.jar", zip file "/data/app/androidx.test.tools.crawler-NErtO20lMAShJiEWuC3FEg==/base.apk", zip file "/data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/base.apk", zip file "/data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/split_config.en.apk", zip file "/data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/split_config.x86.apk", zip file "/data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/split_config.xxhdpi.apk"],nativeLibraryDirectories=[/data/app/androidx.test.tools.crawler-NErtO20lMAShJiEWuC3FEg==/lib/x86, /data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/lib/x86, /data/app/androidx.test.tools.crawler-NErtO20lMAShJiEWuC3FEg==/base.apk!/lib/x86, /data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/base.apk!/lib/x86, /data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/split_config.en.apk!/lib/x86, /data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/split_config.x86.apk!/lib/x86, /data/app/com.umgc.summer2022-Xk_LD14cpApflF7WrqUoQA==/split_config.xxhdpi.apk!/lib/x86, /system/lib]]] couldn't find "libflutter.so"